### PR TITLE
initialize 'ret' and 'key' to some value...

### DIFF
--- a/X509.xs
+++ b/X509.xs
@@ -169,7 +169,7 @@ static HV* hv_exts(X509* x509, int no_name) {
   X509_EXTENSION *ext;
   int i, c, r;
   size_t len = 128;
-  char* key;
+  char* key = NULL;
   SV* rv;
 
   HV* RETVAL = newHV();
@@ -822,7 +822,7 @@ basicC(ext, value)
   PREINIT:
   BASIC_CONSTRAINTS *bs;
   const X509V3_EXT_METHOD *method;
-  int ret;
+  int ret = 0;
 
   CODE:
 


### PR DESCRIPTION
cpanm/CPAN.pm try to compile X509.c with -Wall -Werror and fail due to these being able to be used without initialization, so we're just going to initialize them to sane values.

it might be useful for 'ret' to be initialized to 1 rather than 0?  I'm not sure if that would be more sane or not.

here are the build failures I get under osx/10.6.5:

<pre>
[nrh@plotz <ojects/perl-crypt-openssl-x509] make test
cp X509.pm blib/lib/Crypt/OpenSSL/X509.pm
/opt/local/bin/perl "-Iinc" /opt/local/lib/perl5/5.10.1/ExtUtils/xsubpp  -typemap /opt/local/lib/perl5/5.10.1/ExtUtils/typemap -typemap typemap  X509.xs > X509.xsc && mv X509.xsc X509.c
/usr/bin/gcc-4.2 -c  -I/usr/include/openssl -I/usr/local/include/ssl -I/usr/local/ssl/include -O2 -arch x86_64 -fno-common -DPERL_DARWIN -I/opt/local/include -no-cpp-precomp -fno-strict-aliasing -pipe -fstack-protector -I/opt/local/include -g -Wall -Werror   -DVERSION=\"1.5\" -DXS_VERSION=\"1.5\"  "-I/opt/local/lib/perl5/5.10.1/darwin-2level/CORE"   X509.c
cc1: warnings being treated as errors
X509.c: In function ‘XS_Crypt__OpenSSL__X509__Extension_basicC’:
X509.xs:825: warning: ‘ret’ may be used uninitialized in this function
X509.xs:825: note: ‘ret’ was declared here
make: *** [X509.o] Error 1
[nrh@plotz <ojects/perl-crypt-openssl-x509] vi X509.xs
[nrh@plotz <ojects/perl-crypt-openssl-x509] make test
/opt/local/bin/perl "-Iinc" /opt/local/lib/perl5/5.10.1/ExtUtils/xsubpp  -typemap /opt/local/lib/perl5/5.10.1/ExtUtils/typemap -typemap typemap  X509.xs > X509.xsc && mv X509.xsc X509.c
/usr/bin/gcc-4.2 -c  -I/usr/include/openssl -I/usr/local/include/ssl -I/usr/local/ssl/include -O2 -arch x86_64 -fno-common -DPERL_DARWIN -I/opt/local/include -no-cpp-precomp -fno-strict-aliasing -pipe -fstack-protector -I/opt/local/include -g -Wall -Werror   -DVERSION=\"1.5\" -DXS_VERSION=\"1.5\"  "-I/opt/local/lib/perl5/5.10.1/darwin-2level/CORE"   X509.c
cc1: warnings being treated as errors
X509.c: In function ‘XS_Crypt__OpenSSL__X509_extensions’:
X509.xs:172: warning: ‘key’ may be used uninitialized in this function
X509.xs:172: note: ‘key’ was declared here
make: *** [X509.o] Error 1
</pre>
