### PR TITLE
Fix segfault for exotic keys not handled by OpenSSL

### DIFF
--- a/X509.xs
+++ b/X509.xs
@@ -704,6 +704,10 @@ pubkey_type(x509)
     CODE:
         RETVAL=NULL;
         pkey = X509_get_pubkey(x509);
+
+        if(!pkey)
+            XSRETURN_UNDEF;
+
         if(pkey->type == EVP_PKEY_DSA){
             RETVAL="dsa";
         }


### PR DESCRIPTION
pubkey_type() will segfault if called on exotic certificates with key types that OpenSSL doesn't know how to handle (like GOST)
