### PR TITLE
Patch to make the module compile seamless under Straberry Perl

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,7 @@
 use inc::Module::Install;
 
+use Config;
+
 name('Crypt-OpenSSL-X509');
 license('perl');
 perl_version('5.005');
@@ -10,11 +12,17 @@ bugtracker 'https://github.com/dsully/perl-crypt-openssl-x509/issues';
 
 requires_external_cc();
 
-cc_inc_paths('/usr/include/openssl', '/usr/local/include/ssl', '/usr/local/ssl/include');
-cc_lib_paths('/usr/lib', '/usr/local/lib', '/usr/local/ssl/lib');
+if ($Config::Config{myuname} =~ /^Win(32|64) strawberry-perl\b/) {
+    cc_lib_links("eay$1");
+}
+else {
+    cc_inc_paths('/usr/include/openssl', '/usr/local/include/ssl', '/usr/local/ssl/include');
+    cc_lib_paths('/usr/lib', '/usr/local/lib', '/usr/local/ssl/lib');
 
-cc_lib_links('crypto');
-cc_optimize_flags('-O2 -g -Wall -Werror');
+    cc_lib_links('crypto');
+
+    cc_optimize_flags('-O2 -g -Wall -Werror');
+}
 
 auto_install();
 WriteAll();


### PR DESCRIPTION
Strawberry includes libcrypto but it is called libeay32 there (or I suppose, libeay64 on Win64).

Also the -Wall -Werror are too requiring for the MinGW environment. The default optimizer flags are used instead.
