### PR TITLE
Unbreak build with old OpenSSL.  Tested with 0.9.7a.

### DIFF
--- a/X509.xs
+++ b/X509.xs
@@ -232,10 +232,10 @@ void _decode_netscape(BIO *bio, X509 *x509) {
     os.data   = (unsigned char *)NETSCAPE_CERT_HDR;
     os.length = strlen(NETSCAPE_CERT_HDR);
     ah.header = &os;
-    ah.data   = x509;
+    ah.data   = (char *)x509;
     ah.meth   = X509_asn1_meth();
 
-    ASN1_i2d_bio((i2d_of_void*)i2d_ASN1_HEADER, bio, (unsigned char *)&ah);
+    ASN1_i2d_bio(i2d_ASN1_HEADER, bio, (unsigned char *)&ah);
 
 #endif
 }


### PR DESCRIPTION
The module couldn't build on a somewhat old CentOS 4 box.

```
$ make
...
cc -c  -I/usr/include/openssl -I/usr/local/include/ssl -I/usr/local/ssl/include -D_REENTRANT -D_GNU_SOURCE -fPIC -DAPPLLIB_EXP=/home/seesaa/project/lib:/home/seesaa/cpan/lib:/home/seesaa/cpan/lib/site_perl -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -fPIC -DAPPLLIB_EXP="/home/seesaa/project/lib:/home/seesaa/cpan/lib:/home/seesaa/cpan/lib/site_perl" -O2 -g -Wall -Werror   -DVERSION=\"1.800.2\" -DXS_VERSION=\"1.800.2\" -fPIC "-I/usr/local/perl-5.14/lib/5.14.2/x86_64-linux-thread-multi/CORE"   X509.c
X509.xs: In function `_decode_netscape':
X509.xs:235: warning: assignment from incompatible pointer type
X509.xs:238: error: `i2d_of_void' undeclared (first use in this function)
X509.xs:238: error: (Each undeclared identifier is reported only once
X509.xs:238: error: for each function it appears in.)
X509.xs:238: error: syntax error before ')' token
make: *** [X509.o] Error 1
$ openssl version
OpenSSL 0.9.7a Feb 19 2003
$ uname -a
Linux ****** 2.6.9-89.ELxenU #1 SMP Mon Jun 22 13:00:02 EDT 2009 x86_64 x86_64 x86_64 GNU/Linux
$ cat /etc/redhat-release
CentOS release 4.8 (Final)
```

This patch may break build with even older OpenSSL but I think 0.9.7a is not a bad choice by now as a minimum requirement.  Thanks for your consideration!
