### PR TITLE
Fix path to thawte-ec.cert in MANIFEST

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,5 @@
 certs/thawte.pem
-thawte-ec.pem
+certs/thawte-ec.pem
 certs/vsign1.pem
 certs/balt.pem
 certs/broken-utf8.pem


### PR DESCRIPTION
Doing a `perl Makefile.PL` on a clean dist spit out an error about thawte-ec.pem being missing from the kit.  Looks like this file moved into certs/ at some point, and the MANIFEST never got updated.