### PR TITLE
Print OpenSSL version during tests

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -25,6 +25,7 @@ META.yml			Module meta-data (added by MakeMaker)
 README
 t/pod.t
 t/utf8.t
+t/00-version.t
 t/x509.t
 t/x509-ec.t
 TODO

--- a/t/00-version.t
+++ b/t/00-version.t
@@ -1,0 +1,4 @@
+use Test::More tests => 1;
+my $version = qx(openssl version);
+diag "Running Crypt::OpenSSL::X509 test suite against $version";
+ok(1);


### PR DESCRIPTION
This diagnostic should make it easier to figure out what version of
OpenSSL is causing the UTF-8 issues on other platforms (via CPANT)