### PR TITLE
fix compilation with gcc5

### DIFF
--- a/X509.xs
+++ b/X509.xs
@@ -181,7 +181,7 @@ static HV* hv_exts(X509* x509, int no_name) {
   sv_2mortal((SV*)RETVAL);
   c = X509_get_ext_count(x509);
 
-  if ( ! c > 0 ) {
+  if ( !(c > 0) ) {
     croak("No extensions found\n");
   }
 
@@ -868,7 +868,7 @@ extension(x509, i)
 
   c = X509_get_ext_count(x509);
 
-  if (!c > 0) {
+  if (!(c > 0)) {
     croak("No extensions found\n");
   } else if (i >= c || i < 0) {
     croak("Requested extension index out of range\n");


### PR DESCRIPTION
error was:
X509.xs: In function 'XS_Crypt__OpenSSL__X509_extension':
X509.xs:740:10: error: logical not is only applied to the left hand side of comparison [-Werror=logical-not-parentheses]
   if (!c > 0) {
          ^
cc1: all warnings being treated as errors
Makefile:346: recipe for target 'X509.o' failed