### PR TITLE
Bump version to fix compilation errors

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Crypt::OpenSSL::X509.
 
+1.8.7  Thu May 12 2016
+        - Patch from Bernhard M. Wiedemann to fix compilation errors.
+
 1.8.6  Sat Jan 24 2015
         - Patch from James Hunt to print OpenSSL version during tests.
         - Various MANIFEST fixes.

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Crypt/OpenSSL/X509 version 1.8.6
+Crypt/OpenSSL/X509 version 1.8.7
 ===============================
 
 The README is used to introduce the module and provide instructions on
@@ -31,7 +31,7 @@ COPYRIGHT AND LICENCE
 
 Put the correct copyright and licence information here.
 
-Copyright (C) 2004-2015 Dan Sully
+Copyright (C) 2004-2016 Dan Sully
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself.

--- a/X509.pm
+++ b/X509.pm
@@ -5,7 +5,7 @@ use vars qw($VERSION @EXPORT_OK);
 use Exporter;
 use base qw(Exporter);
 
-$VERSION = '1.806';
+$VERSION = '1.807';
 
 @EXPORT_OK = qw(
   FORMAT_UNDEF FORMAT_ASN1 FORMAT_TEXT FORMAT_PEM FORMAT_NETSCAPE
@@ -419,7 +419,7 @@ Daniel Kahn Gillmor E<lt>dkg@fifthhorseman.netE<gt>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2004-2015 by Dan Sully
+Copyright 2004-2016 by Dan Sully
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself.


### PR DESCRIPTION
@dsully 
I found the same error as https://github.com/dsully/perl-crypt-openssl-x509/pull/43 also occurs on relatively new version of clang.

```bash
$ cc --version
Apple LLVM version 7.3.0 (clang-703.0.29)
Target: x86_64-apple-darwin15.4.0
```

Can you update the version and register it to CPAN?