### PR TITLE
Addressed issue with OpenSSL on OSX 10.11, supporting Homebrew installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 META.yml
+MYMETA.json
+MYMETA.yml
 Makefile
 X509.c
+X509.o
 X509.bs
+blib/
+pm_to_blib

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,17 +13,16 @@ bugtracker 'https://github.com/dsully/perl-crypt-openssl-x509/issues';
 
 requires_external_cc();
 
-    inc '-I/usr/include/openssl -I/usr/local/include/ssl -I/usr/local/ssl/include';
+inc '-I/usr/local/opt/openssl/include -I/usr/include/openssl -I/usr/local/include/ssl -I/usr/local/ssl/include';
+libs '-L/usr/local/opt/openssl/lib -L/usr/lib -L/usr/local/lib -L/usr/local/ssl/lib -lcrypto -lssl';
 
-    libs '-L/usr/lib -L/usr/local/lib -L/usr/local/ssl/lib -lcrypto';
-
-    if ($Config::Config{myuname} =~ /darwin/i) {
-      cc_optimize_flags('-O2 -g -Wall -Werror -Wno-deprecated-declarations');
-    } elsif ($Config::Config{myuname} =~ /sunos|solaris/i) {
-      # Any SunStudio flags?
-    } else {
-      cc_optimize_flags('-O2 -g -Wall -Werror');
-    }
+if ($Config::Config{myuname} =~ /darwin/i) {
+  cc_optimize_flags('-O2 -g -Wall -Werror -Wno-deprecated-declarations');
+} elsif ($Config::Config{myuname} =~ /sunos|solaris/i) {
+  # Any SunStudio flags?
+} else {
+  cc_optimize_flags('-O2 -g -Wall -Werror');
+}
 
 auto_install();
 WriteAll();


### PR DESCRIPTION
Apple is no longer supporting OpenSSL, so developers on the Apple platform have the choices of: MacPorts, Homebrew or own installation. This [blog post](https://langui.sh/2015/07/24/osx-clang-include-lib-search-paths/) explains the head aches this causes.

This patch enables the Homebrew installation. I have lifted some code from [perl-crypt-openssl-pkcs12](https://github.com/dsully/perl-crypt-openssl-pkcs12) into the Makefile.PL, so the implementation should be recognisable.

I might do a patch for the MacPorts support if I can find the time, I am not a MacPorts user myself.

