### PR TITLE
Extension->value() should return asn1parse(1) style hex dump.

### DIFF
--- a/X509.pm
+++ b/X509.pm
@@ -320,9 +320,11 @@ Methods for handling ObjectID objects are given below.
 
 =item value ( )
 
-Return the value or data of the extension.
-FIXME: the value is returned as a string but may represent
-a complex object.
+Return the value of the extension as an asn1parse(1) style hex dump.
+
+=item as_string ( )
+
+Return a human-readable version of the extension as formatted by X509V3_EXT_print. Note that this will return an empty string for OIDs with unknown ASN.1 encodings.
 
 =back
 

--- a/X509.xs
+++ b/X509.xs
@@ -1042,7 +1042,7 @@ value(ext)
     croak("No extension supplied\n");
   }
 
-  ASN1_STRING_print(bio, X509_EXTENSION_get_data(ext));
+  ASN1_STRING_print_ex(bio, X509_EXTENSION_get_data(ext), ASN1_STRFLGS_DUMP_ALL);
 
   RETVAL = sv_bio_final(bio);
 

--- a/X509.xs
+++ b/X509.xs
@@ -78,6 +78,15 @@ static void X509_CRL_get0_signature(const X509_CRL *crl, const ASN1_BIT_STRING *
     *palg = crl->sig_alg;
 }
 
+static void X509_get0_signature(const_ossl11 ASN1_BIT_STRING **psig, const_ossl11 X509_ALGOR **palg,
+                                const_ossl11 X509 *x)
+{
+    if (psig != NULL)
+        *psig = x->signature;
+    if (palg != NULL)
+        *palg = x->sig_alg;
+}
+
 static void DSA_get0_pqg(const DSA *d,
                          const BIGNUM **p, const BIGNUM **q, const BIGNUM **g)
 {


### PR DESCRIPTION
Having the ASN1 hex is much more useful than just a raw print, which renders all non-printable characters as periods - for many extensions is completely useless. You can still use Extension->as_string() to get a printable string if you need it.