### PR TITLE
Expose the Issuer's name hash; provide subject_hash() as an alias to hash()

### DIFF
--- a/X509.pm
+++ b/X509.pm
@@ -111,9 +111,10 @@ Crypt::OpenSSL::X509 - Perl extension to OpenSSL's X509 API.
 
   print $x509->pubkey() . "\n";
   print $x509->subject() . "\n";
-  print $x509->issuer() . "\n";
-  print $x509->email() . "\n";
   print $x509->hash() . "\n";
+  print $x509->email() . "\n";
+  print $x509->issuer() . "\n";
+  print $x509->issuer_hash() . "\n";
   print $x509->notBefore() . "\n";
   print $x509->notAfter() . "\n";
   print $x509->modulus() . "\n";
@@ -195,11 +196,19 @@ Subject name as a string.
 
 Issuer name as a string.
 
+=item issuer_hash
+
+Issuer name hash as a string.
+
 =item serial
 
 Serial number as a string.
 
 =item hash
+
+Alias for subject_hash
+
+=item subject_hash
 
 Subject name hash as a string.
 

--- a/X509.xs
+++ b/X509.xs
@@ -419,12 +419,14 @@ accessor(x509)
   issuer  = 2
   serial  = 3
   hash    = 4
+  subject_hash = 4
   notBefore = 5
   notAfter  = 6
   email     = 7
   version   = 8
   sig_alg_name = 9
   key_alg_name = 10
+  issuer_hash = 11
 
   PREINIT:
   BIO *bio;
@@ -496,6 +498,8 @@ accessor(x509)
     X509_PUBKEY_get0_param(&ppkalg, NULL, NULL, NULL, pkey);
 
     i2a_ASN1_OBJECT(bio, ppkalg);
+  } else if ( ix == 11 ) {
+    BIO_printf(bio, "%08lx", X509_issuer_name_hash(x509));
   }
 
   RETVAL = sv_bio_final(bio);

--- a/t/x509.t
+++ b/t/x509.t
@@ -1,5 +1,5 @@
 
-use Test::More tests => 54;
+use Test::More tests => 56;
 
 BEGIN { use_ok('Crypt::OpenSSL::X509') };
 
@@ -26,8 +26,12 @@ ok($x509->is_selfsigned(), 'is_selfsigned()');
 # Verified with the openssl binary.
 if (Crypt::OpenSSL::X509::OPENSSL_VERSION_NUMBER >= 0x10000000) {
   ok($x509->hash() eq '24ad0b63', 'hash()');
+  ok($x509->subject_hash() eq '24ad0b63', 'subject_hash()');
+  ok($x509->issuer_hash() eq '24ad0b63', 'issuer_hash()');
 } else {
   ok($x509->hash() eq '2edf7016', 'hash()');
+  ok($x509->subject_hash() eq '2edf7016', 'subject_hash()');
+  ok($x509->issuer_hash() eq '2edf7016', 'issuer_hash()');
 }
 
 ok($x509 = Crypt::OpenSSL::X509->new_from_file('certs/thawte.pem'), 'new_from_file()');


### PR DESCRIPTION
Crypt::OpenSSL::X509 doesn't provide an accessor to the issuer's hash, while the library does. This patch exposes that information as a string and creates an alias to the existing hash() accessor (subject_hash) to make it clear which hash you're getting. Updated docs and created tests.