### PR TITLE
Bump of Perl minimum version requirement

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,7 @@ use Config;
 
 name('Crypt-OpenSSL-X509');
 license('perl');
-perl_version('5.005');
+perl_version('5.008');
 all_from('X509.pm');
 
 homepage 'https://github.com/dsully/perl-crypt-openssl-x509';

--- a/t/utf8.t
+++ b/t/utf8.t
@@ -1,4 +1,5 @@
 
+use 5.008;
 use Test::More tests => 11;
 use Encode;
 


### PR DESCRIPTION
# Description

Updated Perl minimum requirement to version 5.8, since we specified 5.005, but used newer syntax (5.8)

Actually addresses an unreported issue of the minimum requirement not being correct.

## Minor improvement

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Changes have been manually tested (please provide information on test platform using the fields below)
