### PR TITLE
use --installed option while executing brew

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,7 +16,7 @@ bugtracker 'https://github.com/dsully/perl-crypt-openssl-x509/issues';
 
 requires_external_cc();
 
-if ($^O ne 'MSWin32' and my $prefix = `brew --prefix openssl 2>@{[File::Spec->devnull]}`) {
+if ($^O ne 'MSWin32' and my $prefix = `brew --prefix --installed openssl 2>@{[File::Spec->devnull]}`) {
   chomp $prefix;
   inc "-I$prefix/include";
   libs "-L$prefix/lib -lcrypto -lssl";


### PR DESCRIPTION
# Description

I created #81, where I suggested that we can use `brew --prefix openssl` to probe openssl libraries.
But it turns out that `brew --prefix openssl` prints a directory even if openssl formula is not installed. I'm sorry.
```
❯ brew --prefix --help
Usage: brew --prefix [--unbrewed] [--installed] [formula ...]
...
If formula is provided, display the location where formula is or would be
installed.
...
      --installed                  Outputs nothing and returns a failing
                                   status code if formula is not installed.
```

This PR adds `--installed` option  to `brew --prefix` command so that `brew --prefix` prints a directory only if openssl formula is actually installed. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- Operating system and version: macOS / linux
- Crypt::OpenSSL::X509 version: 1.906
- Perl version: 5.32.1
- OpenSSL version: 1.1.1k