### PR TITLE
Only make warnings errors for AUTHOR_TESTING

### DIFF
--- a/.github/workflows/macos-10.15.yml
+++ b/.github/workflows/macos-10.15.yml
@@ -20,19 +20,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
+      - name: uses install-with-cpanm
+        uses: perl-actions/install-with-cpanm@v1
+        with:
+          cpanfile: "cpanfile"
+          sudo: false
       # REF: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md (see link above, at the time of writing we get Perl 5.34.0 with macOS 10.15)
-      - name: Set up Perl
-        run: |
-          brew install perl
-          curl https://cpanmin.us | perl - App::cpanminus -n
-          echo "/Users/runner/perl5/bin" >> $GITHUB_PATH
       - name: perl -V
         run: perl -V
 
       - name: Run Tests
         run: |
-          curl -sL https://cpanmin.us/ | perl - -nq --with-develop --installdeps -v .
           perl Makefile.PL
           make
           make test

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,13 @@
 # Revision history for Perl extension Crypt::OpenSSL::X509
 
+## 1.9.13-TRIAL Sun Feb 20 21:31:44 CET 2022
+
+- The distribution has changed distribution toolchain from Module::Install to Dist::Zilla, thanks to @skaji for PR [#96](https://github.com/dsully/perl-crypt-openssl-x509/pull/96) and thanks to @timlegge for the review of the proposed changes
+
+- The macOS CI jobs have been improved with PRs [#98](https://github.com/dsully/perl-crypt-openssl-x509/pull/98) and [#99](https://github.com/dsully/perl-crypt-openssl-x509/pull/99) from @timlegge
+
+- This is a TRIAL release, in order to get some feedback from CPAN-testers prior to making a proper public release, since the changes to the build system has been quite significant. Additional trial releases might follow, based on findings and feedback
+
 ## 1.9.12 Wed Jan 19 07:46:10 CET 2022
 
 - Repair upload, see release 1.9.11, thank you @timlegge for reporting this

--- a/Changes.md
+++ b/Changes.md
@@ -1,10 +1,14 @@
 # Revision history for Perl extension Crypt::OpenSSL::X509
 
-## 1.9.13-TRIAL Sun Feb 20 21:31:44 CET 2022
+## 1.9.13 Sat Feb 26 00:36:28 CET 2022
 
 - The distribution has changed distribution toolchain from Module::Install to Dist::Zilla, thanks to @skaji for PR [#96](https://github.com/dsully/perl-crypt-openssl-x509/pull/96) and thanks to @timlegge for the review of the proposed changes
 
 - The macOS CI jobs have been improved with PRs [#98](https://github.com/dsully/perl-crypt-openssl-x509/pull/98) and [#99](https://github.com/dsully/perl-crypt-openssl-x509/pull/99) from @timlegge
+
+## 1.9.13-TRIAL Sun Feb 20 21:31:44 CET 2022
+
+- Release leading up to 1.9.13, see that release for details
 
 - This is a TRIAL release, in order to get some feedback from CPAN-testers prior to making a proper public release, since the changes to the build system has been quite significant. Additional trial releases might follow, based on findings and feedback
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -70,7 +70,7 @@ my %WriteMakefileArgs = (
   "TEST_REQUIRES" => {
     "Test::Pod" => "1.00"
   },
-  "VERSION" => "1.912",
+  "VERSION" => "1.913",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/X509.pm
+++ b/X509.pm
@@ -8,7 +8,7 @@ use base qw(Exporter);
 
 use Convert::ASN1;
 
-our $VERSION = '1.912';
+our $VERSION = '1.913';
 
 our @EXPORT_OK = qw(
   FORMAT_UNDEF FORMAT_ASN1 FORMAT_TEXT FORMAT_PEM

--- a/maint/Makefile_header.PL
+++ b/maint/Makefile_header.PL
@@ -22,7 +22,13 @@ if ($^O eq 'MSWin32') {
   }
 }
 
-my $cc_option_flags = '-O2 -g -Wall -Werror';
+my $cc_option_flags = '-O2 -g';
+
+if ($Config::Config{cc} =~ /gcc/i) {
+  $cc_option_flags .= $ENV{AUTHOR_TESTING} ? ' -Wall -Werror' : ' -Wall';
+} else {
+  $cc_option_flags .= '';
+}
 
 if ($Config{gccversion} =~ /llvm/i) {
   if ( $^O eq 'darwin' && $Config{gccversion} =~ /LLVM 12.0.5/) {
@@ -41,7 +47,7 @@ if ($Config{gccversion} =~ /llvm/i) {
 }
 
 if ($Config{myuname} =~ /sunos|solaris/i) {
-  # Any SunStudio flags?
+  $args{OPTIMIZE} = $cc_option_flags;
 } else {
   $args{OPTIMIZE} = $cc_option_flags;
 }


### PR DESCRIPTION
# Description

Please include a summary of the proposed improvement or addressed issue.
This does two things:

1. Only enable -Wall and -Werror if the compiler is gcc 
2. Only enable -Werror of $ENV{AUTHOR_TESTING} is set

Fixes/addresses (If applicable) # (issue)
Fixes #95 
Fixes #45 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- Operating system and version 
solaris

Please see the issue template for a more information on provided the requested information.

