### PR TITLE
Only make warnings errors for AUTHOR_TESTING

### DIFF
--- a/maint/Makefile_header.PL
+++ b/maint/Makefile_header.PL
@@ -22,7 +22,13 @@ if ($^O eq 'MSWin32') {
   }
 }
 
-my $cc_option_flags = '-O2 -g -Wall -Werror';
+my $cc_option_flags = '-O2 -g';
+
+if ($Config::Config{cc} =~ /gcc/i) {
+  $cc_option_flags .= $ENV{AUTHOR_TESTING} ? ' -Wall -Werror' : ' -Wall';
+} else {
+  $cc_option_flags .= '';
+}
 
 if ($Config{gccversion} =~ /llvm/i) {
   if ( $^O eq 'darwin' && $Config{gccversion} =~ /LLVM 12.0.5/) {
@@ -41,7 +47,7 @@ if ($Config{gccversion} =~ /llvm/i) {
 }
 
 if ($Config{myuname} =~ /sunos|solaris/i) {
-  # Any SunStudio flags?
+  $args{OPTIMIZE} = $cc_option_flags;
 } else {
   $args{OPTIMIZE} = $cc_option_flags;
 }


### PR DESCRIPTION
# Description

Please include a summary of the proposed improvement or addressed issue.
This does two things:

1. Only enable -Wall and -Werror if the compiler is gcc 
2. Only enable -Werror of $ENV{AUTHOR_TESTING} is set

Fixes/addresses (If applicable) # (issue)
Fixes #95 
Fixes #45 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- Operating system and version 
solaris

Please see the issue template for a more information on provided the requested information.

