### PR TITLE
Openssl ver updates

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,7 +31,12 @@ if ($^O eq 'MSWin32') {
   }
 }
 
-my $cc_option_flags = '-O2 -g -Wall -Werror';
+#my $api_ver = '0x00908000L';  # (version 0.9.8)
+my $api_ver = '0x10000000L';  # (version 1.0.0)
+#my $api_ver = '0x10100000L';  # (version 1.1.0)
+
+#my $cc_option_flags = "-DOPENSSL_API_COMPAT=$api_ver -O2 -g -Wall -Werror";
+my $cc_option_flags = "-DOPENSSL_NO_DEPRECATED_0_9_8 -O2 -g -Wall -Werror";
 
 if ($Config{gccversion} =~ /llvm/i) {
   if ( $^O eq 'darwin' && $Config{gccversion} =~ /LLVM 12.0.5/) {

--- a/maint/Makefile_header.PL
+++ b/maint/Makefile_header.PL
@@ -22,7 +22,11 @@ if ($^O eq 'MSWin32') {
   }
 }
 
-my $cc_option_flags = '-O2 -g -Wall -Werror';
+#my $api_ver = '0x00908000L';  # (version 0.9.8)
+#my $api_ver = '0x10000000L';  # (version 1.0.0)
+my $api_ver = '0x10100000L';  # (version 1.1.0)
+
+my $cc_option_flags = "-DOPENSSL_API_COMPAT=$api_ver -O2 -g -Wall -Werror";
 
 if ($Config{gccversion} =~ /llvm/i) {
   if ( $^O eq 'darwin' && $Config{gccversion} =~ /LLVM 12.0.5/) {


### PR DESCRIPTION
@jonasbn This is just a test for discussion/review.  I figured before I (or someone else) started on opensslv3 support it would be good to ensure that the current versioning was correct.  This seems to sort a few issue.

I was able to test on:

OpenSSL 1.0.2u  20 Dec 2019
OpenSSL 1.1.1l  24 Aug 2021

Not sure if you have access to 0.9.8 easily.  It took me half the evening to get a 1.0.2 environment running.

Both seemed to work fine and the Makefile.Pl has a couple of options to allow testing it a littl better.

At this point I at least none of the earlier deprecated functions should mess with version 3.

Tim
Tim