### PR TITLE
LLVM 12.0.0 also needs workaround

### DIFF
--- a/maint/Makefile_header.PL
+++ b/maint/Makefile_header.PL
@@ -25,7 +25,7 @@ if ($^O eq 'MSWin32') {
 my $cc_option_flags = '-O2 -g -Wall -Werror';
 
 if ($Config{gccversion} =~ /llvm/i) {
-  if ( $^O eq 'darwin' && $Config{gccversion} =~ /LLVM 12.0.5/) {
+  if ( $^O eq 'darwin' && $Config{gccversion} =~ /LLVM 12.0.[0-5]/) {
     $cc_option_flags .= ' -Wno-deprecated-declarations -Wno-compound-token-split-by-macro';
   } else {
     $cc_option_flags .= ' -Wno-deprecated-declarations';


### PR DESCRIPTION
# Description

LLVM 12.0.0 looks also needing `-Wno-compound-token-split-by-macro` option which has been introduced by #98 for 12.0.5.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- Operating system and version: GitHub Action virtual environment for macos-latest
- Crypt::OpenSSL::X509 version: 1.9.13
- Perl version: 5.34.1, gccversion='Apple LLVM 12.0.0 (clang-1200.0.32.29)'
- OpenSSL version: 1.1.1n
