### PR TITLE
Clean up to llvm command line options

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -28,7 +28,7 @@ if ($Config::Config{cc} =~ /gcc/i) {
 }
 
 if ($Config{gccversion} =~ /llvm/i) {
-  $cc_option_flags .= ' -Wno-deprecated-declarations';
+  $cc_option_flags .= ' -Wall -Wno-deprecated-declarations';
 
   if ($Config{gccversion} =~ /llvm 12/i) {
     $cc_option_flags .= ' -Wno-compound-token-split-by-macro';

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -33,15 +33,21 @@ if ($^O eq 'MSWin32') {
 
 my $cc_option_flags = '-O2 -g -Wall -Werror';
 
+# Example from macOS (see prototypes/config.pl)
+# gccversion = Apple LLVM 13.0.0 (clang-1300.0.29.30)
 if ($Config{gccversion} =~ /llvm/i) {
-  if ( $^O eq 'darwin' && $Config{gccversion} =~ /LLVM 12.0.5/) {
-    $cc_option_flags .= ' -Wno-deprecated-declarations -Wno-compound-token-split-by-macro';
-  } else {
-    $cc_option_flags .= ' -Wno-deprecated-declarations';
+  $cc_option_flags .= ' -Wno-deprecated-declarations';
+
+  if ($Config{gccversion} =~ /llvm 12/i) {
+    $cc_option_flags .= ' -Wno-compound-token-split-by-macro';
   }
 
   if ($Config{gccversion} =~ /llvm 13/i) {
-      $cc_option_flags .= ' -Wno-compound-token-split-by-macro';
+    $cc_option_flags .= ' -Wno-compound-token-split-by-macro';
+  }
+
+  if ($Config{gccversion} =~ /llvm 14/i) {
+    $cc_option_flags .= ' -Wno-compound-token-split-by-macro';
   }
 
   if ($Config{perl_version} <= 20) {

--- a/maint/Makefile_header.PL
+++ b/maint/Makefile_header.PL
@@ -25,14 +25,18 @@ if ($^O eq 'MSWin32') {
 my $cc_option_flags = '-O2 -g -Wall -Werror';
 
 if ($Config{gccversion} =~ /llvm/i) {
-  if ( $^O eq 'darwin' && $Config{gccversion} =~ /LLVM 12.0.[0-5]/) {
-    $cc_option_flags .= ' -Wno-deprecated-declarations -Wno-compound-token-split-by-macro';
-  } else {
-    $cc_option_flags .= ' -Wno-deprecated-declarations';
+  $cc_option_flags .= ' -Wno-deprecated-declarations';
+
+  if ($Config{gccversion} =~ /llvm 12/i) {
+    $cc_option_flags .= ' -Wno-compound-token-split-by-macro';
   }
 
   if ($Config{gccversion} =~ /llvm 13/i) {
-      $cc_option_flags .= ' -Wno-compound-token-split-by-macro';
+    $cc_option_flags .= ' -Wno-compound-token-split-by-macro';
+  }
+
+  if ($Config{gccversion} =~ /llvm 14/i) {
+    $cc_option_flags .= ' -Wno-compound-token-split-by-macro';
   }
 
   if ($Config{perl_version} <= 20) {

--- a/maint/Makefile_header.PL
+++ b/maint/Makefile_header.PL
@@ -19,7 +19,7 @@ if ($Config::Config{cc} =~ /gcc/i) {
 }
 
 if ($Config{gccversion} =~ /llvm/i) {
-  $cc_option_flags .= ' -Wno-deprecated-declarations';
+  $cc_option_flags .= ' -Wall -Wno-deprecated-declarations';
 
   if ($Config{gccversion} =~ /llvm 12/i) {
     $cc_option_flags .= ' -Wno-compound-token-split-by-macro';


### PR DESCRIPTION
- Cleaned up in the LLVM CLI flag handling
- Added ALL warning to llvm section

This is a follow up on PR #98 

# Description

Please include a summary of the proposed improvement or addressed issue.

Fixes/addresses (If applicable) # (issue)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- Operating system and version

`Darwin silverrocket 21.4.0 Darwin Kernel Version 21.4.0: Fri Mar 18 00:46:32 PDT 2022; root:xnu-8020.101.4~15/RELEASE_ARM64_T6000 arm64`

- Crypt::OpenSSL::X509 version

`master` branch

- Perl version

`This is perl 5, version 34, subversion 0 (v5.34.0) built for darwin-2level`

- OpenSSL version

`OpenSSL 1.1.1n  15 Mar 2022`
