### PR TITLE
Explicitly installing OpenSSL 1 (1.1)

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -19,6 +19,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: install dependencies
+        run: |
+          brew install openssl@1.1
       - name: uses install-with-cpanm
         uses: perl-actions/install-with-cpanm@v1
         with:


### PR DESCRIPTION
# Description

This change explicitly installs OpenSSL version 1. I can see from broken builds that version 3 is used, even though the documentation mentions version 1.

REF: 

- https://github.com/actions/runner-images#available-images
- https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md

## Type of change

Please delete options that are not relevant.

- [X] This change is maintenance to infrastructure framework or build system

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings

## Test / Development Platform Information

This will be tested using GitHub Actions