### PR TITLE
explicitly link libz on AIX

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,8 +10,13 @@ use ExtUtils::MakeMaker;
 use Config;
 use Crypt::OpenSSL::Guess qw(openssl_lib_paths openssl_inc_paths);
 
+my $libs = ' -lssl -lcrypto';
+if ($Config{osname} eq 'aix') {
+  $libs = $libs . ' -lz';
+}
+
 my %args = (
-  LIBS => [openssl_lib_paths().' -lssl -lcrypto'],
+  LIBS => [openssl_lib_paths(). $libs],
   INC => openssl_inc_paths(),
 );
 

--- a/maint/Makefile_header.PL
+++ b/maint/Makefile_header.PL
@@ -1,8 +1,13 @@
 use Config;
 use Crypt::OpenSSL::Guess qw(openssl_lib_paths openssl_inc_paths);
 
+my $libs = ' -lssl -lcrypto';
+if ($Config{osname} eq 'aix') {
+  $libs = $libs . ' -lz';
+}
+
 my %args = (
-  LIBS => [openssl_lib_paths().' -lssl -lcrypto'],
+  LIBS => [openssl_lib_paths(). $libs],
   INC => openssl_inc_paths(),
 );
 


### PR DESCRIPTION
# Description

Fixes issue on AIX where libz is not linked

Fixes/addresses (If applicable) # (issue)

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- Operating system and version
- Crypt::OpenSSL::X509 1.915
- Perl version 5.38
- OpenSSL version OpenSSL 1.0.2u  20 Dec 2019
