### PR TITLE
fix/discarded qualifiers

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,6 @@
 # Revision history for Perl extension Crypt::OpenSSL::X509
 
-## 2.1.0 2026-05-16
+## 2.1.0-TRIAL 2026-05-16
 
 - Applied PR [#124](https://github.com/dsully/perl-crypt-openssl-x509/pull/124) adding OpenSSL 4.0 compatibility, addressing issue [#123](https://github.com/dsully/perl-crypt-openssl-x509/issues/123). OpenSSL 4.0.0 made `ASN1_STRING` types opaque, breaking direct struct member access. Conditional compilation (`OPENSSL_VERSION_NUMBER >= 0x40000000L`) now uses accessor functions (`ASN1_STRING_length()`, `ASN1_STRING_get0_data()`, `ASN1_STRING_type()`) for OpenSSL 4.x while maintaining backward compatibility with earlier versions. Fixed functions: `sig_print()`, `ia5string()`, `keyid_data()`, `is_asn1_type()`, `encoding()`. Also fixed a buffer over-read and memory leaks in `ia5string()` and `keyid_data()`. Added `OPENSSL4_TESTING.md` with build and test instructions and `scripts/test.sh` for testing against multiple OpenSSL versions. Contributed by @jonasbn with co-authoring from Copilot and Claude
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,13 @@
 # Revision history for Perl extension Crypt::OpenSSL::X509
 
+## 2.1.1-TRIAL 2026-05-28
+
+- Fixed const-correctness warnings reported by @ppisar in follow-up feedback on issue [#123](https://github.com/dsully/perl-crypt-openssl-x509/issues/123). OpenSSL 1.1.0+ returns const-qualified pointers from several accessor functions; added explicit casts at read-only call sites to resolve `-Wdiscarded-qualifiers` and `-Wincompatible-pointer-types-discards-qualifiers` warnings. Affected functions: `X509_get_ext()`, `X509_get_subject_name()`, `X509_get_issuer_name()`, `X509_get_X509_PUBKEY()`, `X509_EXTENSION_get_object()`, `X509_CRL_get_issuer()`, `X509_NAME_get_entry()`. Contributed by @jonasbn with co-authoring from Claude
+
+- Improved OpenSSL version detection in tests when `OPENSSL_PREFIX` is set. Test suite now reports the version of the OpenSSL library actually being tested (as specified by `scripts/test.sh`) rather than the default PATH binary. Also added warning when `OPENSSL_PREFIX` points to a missing or non-executable binary to avoid silent failures. Contributed by @jonasbn with co-authoring from Claude
+
+- This is a TRIAL release following up on 2.1.0-TRIAL, addressing remaining compiler warnings while maintaining full OpenSSL 1.0.x through 4.x compatibility. Additional trial releases may follow based on CPAN-testers feedback
+
 ## 2.1.0-TRIAL 2026-05-16
 
 - Applied PR [#124](https://github.com/dsully/perl-crypt-openssl-x509/pull/124) adding OpenSSL 4.0 compatibility, addressing issue [#123](https://github.com/dsully/perl-crypt-openssl-x509/issues/123). OpenSSL 4.0.0 made `ASN1_STRING` types opaque, breaking direct struct member access. Conditional compilation (`OPENSSL_VERSION_NUMBER >= 0x40000000L`) now uses accessor functions (`ASN1_STRING_length()`, `ASN1_STRING_get0_data()`, `ASN1_STRING_type()`) for OpenSSL 4.x while maintaining backward compatibility with earlier versions. Fixed functions: `sig_print()`, `ia5string()`, `keyid_data()`, `is_asn1_type()`, `encoding()`. Also fixed a buffer over-read and memory leaks in `ia5string()` and `keyid_data()`. Added `OPENSSL4_TESTING.md` with build and test instructions and `scripts/test.sh` for testing against multiple OpenSSL versions. Contributed by @jonasbn with co-authoring from Copilot and Claude

--- a/X509.pm
+++ b/X509.pm
@@ -8,7 +8,7 @@ use base qw(Exporter);
 
 use Convert::ASN1;
 
-use version; our $VERSION = version->declare('2.1.0');
+use version; our $VERSION = version->declare('2.1.1');
 
 our @EXPORT_OK = qw(
   FORMAT_UNDEF FORMAT_ASN1 FORMAT_TEXT FORMAT_PEM

--- a/X509.xs
+++ b/X509.xs
@@ -261,6 +261,7 @@ static HV* hv_exts(X509* x509, int no_name) {
   int i, c, r;
   size_t len = 128;
   char* key = NULL;
+  const char* ckey = NULL;
   SV* rv;
 
   HV* RETVAL = newHV();
@@ -273,6 +274,7 @@ static HV* hv_exts(X509* x509, int no_name) {
 
   for (i = 0; i < c; i++) {
     r = 0;
+    ckey = NULL;
 
     ext = X509_get_ext(x509, i);
 
@@ -284,14 +286,15 @@ static HV* hv_exts(X509* x509, int no_name) {
 
        key = malloc(sizeof(char) * (len + 1)); /*FIXME will it leak?*/
        r = OBJ_obj2txt(key, len, X509_EXTENSION_get_object(ext), no_name);
+       ckey = key;
 
     } else if (no_name == 2) {
 
-       key = (char*)OBJ_nid2sn(OBJ_obj2nid(X509_EXTENSION_get_object(ext)));
-       r = strlen(key);
+       ckey = OBJ_nid2sn(OBJ_obj2nid(X509_EXTENSION_get_object(ext)));
+       r = strlen(ckey);
     }
 
-    if (! hv_store(RETVAL, key, r, rv, 0) ) croak("Error storing extension in hash\n");
+    if (! hv_store(RETVAL, ckey, r, rv, 0) ) croak("Error storing extension in hash\n");
   }
 
   return RETVAL;
@@ -305,7 +308,7 @@ BOOT:
 {
   HV *stash = gv_stashpvn("Crypt::OpenSSL::X509", 20, TRUE);
 
-  struct { char *n; I32 v; } Crypt__OpenSSL__X509__const[] = {
+  struct { const char *n; I32 v; } Crypt__OpenSSL__X509__const[] = {
 
   {"OPENSSL_VERSION_NUMBER", OPENSSL_VERSION_NUMBER},
   {"FORMAT_UNDEF", FORMAT_UNDEF},
@@ -321,7 +324,7 @@ BOOT:
   {"V_ASN1_IA5STRING",  V_ASN1_IA5STRING},
   {Nullch,0}};
 
-  char *name;
+  const char *name;
   int i;
 
   for (i = 0; (name = Crypt__OpenSSL__X509__const[i].n); i++) {
@@ -951,7 +954,7 @@ pubkey(x509)
   OUTPUT:
   RETVAL
 
-char*
+const char*
 pubkey_type(x509)
         Crypt::OpenSSL::X509 x509;
     PREINIT:
@@ -1556,7 +1559,7 @@ is_printableString(name_entry, asn1_type =  V_ASN1_PRINTABLESTRING)
   OUTPUT:
   RETVAL
 
-char*
+const char*
 encoding(name_entry)
   Crypt::OpenSSL::X509::Name_Entry name_entry;
 

--- a/X509.xs
+++ b/X509.xs
@@ -276,7 +276,7 @@ static HV* hv_exts(X509* x509, int no_name) {
     r = 0;
     ckey = NULL;
 
-    ext = X509_get_ext(x509, i);
+    ext = (X509_EXTENSION *)X509_get_ext(x509, i);
 
     if (ext == NULL) croak("Extension %d unavailable\n", i);
 
@@ -448,9 +448,9 @@ accessor(x509)
   if (ix == 1 || ix == 2) {
 
     if (ix == 1) {
-      name = X509_get_subject_name(x509);
+      name = (X509_NAME *)X509_get_subject_name(x509);
     } else {
-      name = X509_get_issuer_name(x509);
+      name = (X509_NAME *)X509_get_issuer_name(x509);
     }
 
     /* this is prefered over X509_NAME_oneline() */
@@ -507,7 +507,7 @@ accessor(x509)
     X509_PUBKEY *pkey;
     ASN1_OBJECT *ppkalg;
 
-    pkey = X509_get_X509_PUBKEY(x509);
+    pkey = (X509_PUBKEY *)X509_get_X509_PUBKEY(x509);
     X509_PUBKEY_get0_param(&ppkalg, NULL, NULL, NULL, pkey);
 
     i2a_ASN1_OBJECT(bio, ppkalg);
@@ -530,9 +530,9 @@ subject_name(x509)
 
   CODE:
   if (ix == 1) {
-    RETVAL = X509_get_subject_name(x509);
+    RETVAL = (X509_NAME *)X509_get_subject_name(x509);
   } else {
-    RETVAL = X509_get_issuer_name(x509);
+    RETVAL = (X509_NAME *)X509_get_issuer_name(x509);
   }
 
   OUTPUT:
@@ -1011,7 +1011,7 @@ extension(x509, i)
   } else if (i >= c || i < 0) {
     croak("Requested extension index out of range\n");
   } else {
-    ext = X509_get_ext(x509, i);
+    ext = (X509_EXTENSION *)X509_get_ext(x509, i);
   }
 
   if (ext == NULL) {
@@ -1066,7 +1066,7 @@ object(ext)
     croak("No extension supplied\n");
   }
 
-  RETVAL = X509_EXTENSION_get_object(ext);
+  RETVAL = (ASN1_OBJECT *)X509_EXTENSION_get_object(ext);
 
   OUTPUT:
   RETVAL
@@ -1186,7 +1186,7 @@ bit_string(ext)
   CODE:
   bio = sv_bio_create();
 
-  object = X509_EXTENSION_get_object(ext);
+  object = (ASN1_OBJECT *)X509_EXTENSION_get_object(ext);
   nid = OBJ_obj2nid(object);
   bit_str = X509V3_EXT_d2i(ext);
 
@@ -1267,7 +1267,7 @@ keyid_data(ext)
   CODE:
 
   bio    = sv_bio_create();
-  object = X509_EXTENSION_get_object(ext);
+  object = (ASN1_OBJECT *)X509_EXTENSION_get_object(ext);
   nid    = OBJ_obj2nid(object);
 
   if (nid == NID_authority_key_identifier) {
@@ -1379,7 +1379,7 @@ entries(name)
   c = X509_NAME_entry_count(name);
 
   for (i = 0; i < c; i++) {
-    rv = sv_make_ref("Crypt::OpenSSL::X509::Name_Entry", (void*)X509_NAME_get_entry(name, i));
+    rv = sv_make_ref("Crypt::OpenSSL::X509::Name_Entry", (void*)(X509_NAME_ENTRY *)X509_NAME_get_entry(name, i));
     av_push(RETVAL, rv);
   }
 
@@ -1452,7 +1452,7 @@ get_entry_by_type(name, type, lastpos = -1)
   }
 
   i = X509_NAME_get_index_by_NID(name, nid, lastpos);
-  RETVAL = X509_NAME_get_entry(name, i);
+  RETVAL = (X509_NAME_ENTRY *)X509_NAME_get_entry(name, i);
 
   OUTPUT:
   RETVAL
@@ -1655,7 +1655,7 @@ CRL_accessor(crl)
   bio = sv_bio_create();
 
   if (ix == 1) {
-    name = X509_CRL_get_issuer(crl);
+    name = (X509_NAME *)X509_CRL_get_issuer(crl);
     sv_bio_utf8_on(bio);
     X509_NAME_print_ex(bio, name, 0, (XN_FLAG_SEP_CPLUS_SPC | ASN1_STRFLGS_UTF8_CONVERT) & ~ASN1_STRFLGS_ESC_MSB);
 


### PR DESCRIPTION
- **Fix -Wdiscarded-qualifiers warnings by preserving const qualifiers**
- **Fix remaining -Wincompatible-pointer-types-discards-qualifiers warnings**
- **Updated Changes and bumped version number for next TRIAL release**
- **Change log updated and release prepared**

# Description

Addresses warnings as outlined in issue #123

## Type of change

Please delete options that are not relevant.
 
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is maintenance to infrastructure framework or build system

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- Operating system and version

> macOS Tahoe 26.5

- Crypt::OpenSSL::X509 version

> 2.1.1-TRIAL

- Perl version

> This is perl 5, version 40, subversion 2 (v5.40.2) built for darwin-2level

- OpenSSL version

> 4.x
> 3.5.x
> 3.0
> 3.x

Please see the issue template for a more information on provided the requested information.

