### PR TITLE
Move -DOPENSSL_API_COMPAT from OPTIMIZE to CCFLAGS

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,7 +24,9 @@ my %args = (
 #my $api_ver = '0x10000000L';  # (version 1.0.0)
 my $api_ver = '0x10100000L';  # (version 1.1.0)
 
-my $cc_option_flags = " -DOPENSSL_API_COMPAT=$api_ver -O2 -g";
+$args{CCFLAGS} = "$Config::Config{ccflags} -DOPENSSL_API_COMPAT=$api_ver";
+
+my $cc_option_flags = " -O2 -g";
 
 if ($Config::Config{cc} =~ /gcc/i) {
   $cc_option_flags .= $ENV{AUTHOR_TESTING} ? ' -Wall -Werror' : ' -Wall';

--- a/maint/Makefile_header.PL
+++ b/maint/Makefile_header.PL
@@ -15,7 +15,9 @@ my %args = (
 #my $api_ver = '0x10000000L';  # (version 1.0.0)
 my $api_ver = '0x10100000L';  # (version 1.1.0)
 
-my $cc_option_flags = " -DOPENSSL_API_COMPAT=$api_ver -O2 -g";
+$args{CCFLAGS} = "$Config::Config{ccflags} -DOPENSSL_API_COMPAT=$api_ver";
+
+my $cc_option_flags = " -O2 -g";
 
 if ($Config::Config{cc} =~ /gcc/i) {
   $cc_option_flags .= $ENV{AUTHOR_TESTING} ? ' -Wall -Werror' : ' -Wall';


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Moves `-DOPENSSL_API_COMPAT=$api_ver` out of `$cc_option_flags` / `OPTIMIZE` and into `CCFLAGS`, appended to `$Config::Config{ccflags}`
- `OPTIMIZE` can be overridden by the user (e.g. `perl Makefile.PL OPTIMIZE='-Wdiscarded-qualifiers'`), which previously silently dropped the define and caused OpenSSL 3.0 deprecation warnings to flood the build output
- `CCFLAGS` is always applied regardless of user-supplied `OPTIMIZE`, and existing system compiler flags are preserved (not replaced)

Reported by @ppisar in #123 (final comment, 2026-05-29).

## Test plan

- [ ] Run `perl Makefile.PL && make` — clean build, no OpenSSL deprecation warnings
- [ ] Run `perl Makefile.PL OPTIMIZE='-Wdiscarded-qualifiers' && make` — verify `-DOPENSSL_API_COMPAT` is still applied (no deprecation warnings) and the custom `OPTIMIZE` flag takes effect
- [ ] Run `make test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)