### PR TITLE
Fix has_extension_oid when multiple certificates are instantiated

### DIFF
--- a/X509.pm
+++ b/X509.pm
@@ -19,11 +19,7 @@ sub Crypt::OpenSSL::X509::has_extension_oid {
   my $x509 = shift;
   my $oid  = shift;
 
-  if (not $Crypt::OpenSSL::X509::exts_by_oid) {
-      $Crypt::OpenSSL::X509::exts_by_oid = $x509->extensions_by_oid;
-  }
-
-  return $$Crypt::OpenSSL::X509::exts_by_oid{$oid} ? 1 : 0;
+  return ${$x509->extensions_by_oid}{$oid} ? 1 : 0;
 }
 
 sub Crypt::OpenSSL::X509::Extension::is_critical {

--- a/t/x509.t
+++ b/t/x509.t
@@ -1,5 +1,5 @@
 
-use Test::More tests => 59;
+use Test::More tests => 60;
 
 BEGIN { use_ok('Crypt::OpenSSL::X509') };
 
@@ -58,6 +58,8 @@ ok($$exts{'2.5.29.19'}->basicC('ca'), 'basicConstraints CA: TRUE 2.4.1');
 ok($$exts{'2.5.29.19'}->as_string() eq $$exts{'2.5.29.19'}->to_string(), 'as_string is an alias of to_string');
 
 ok($x509_b = Crypt::OpenSSL::X509->new_from_file('certs/balt.pem'), 'new_from_file()');
+ok($x509_b->has_extension_oid('2.5.29.14'), 'has_extension_oid(2.5.29.14)');
+
 ok(my $exts_b = $x509_b->extensions_by_name(), 'extensions_by_name()');
 ok(not($$exts_b{'subjectKeyIdentifier'}->is_critical()), 'subjectKeyIdentifier not critical');
 my $subkeyid = (join ':', map{sprintf '%X', ord($_)} split //, $$exts_b{'subjectKeyIdentifier'}->keyid_data());


### PR DESCRIPTION
# Description

This MR addresses an issue I found while developing an application that processes multiple certificates in a single Perl process.

The previous code used a package variable to store a cache of extensions. Which means the list of extensions is shared for all certificates currently being processed.

The proposed unit test highlights the issue: it fails with the previous code because has_extension_oid has previously been called on a different certificate that doesn't have this extension

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- Operating system and version: Debian 13.5
- Crypt::OpenSSL::X509 version: master
- Perl version: 5.40.1
- OpenSSL version: 3.5.6

Please see the issue template for a more information on provided the requested information.
