### PR TITLE
Security fixes: CVE-2026-58101 and CVE-2026-58102"

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4.2.0
       - name: install dependencies
         run: |
-          brew install openssl@1.1
+          brew install openssl@3
       - name: uses install-with-cpanm
         uses: perl-actions/install-with-cpanm@v1.7
         with:
@@ -32,7 +32,13 @@ jobs:
         run: perl -V
 
       - name: Run Tests
+        env:
+          OPENSSL_PREFIX: /opt/homebrew/opt/openssl@3
         run: |
+          export PKG_CONFIG_PATH="$OPENSSL_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
+          export LDFLAGS="-L$OPENSSL_PREFIX/lib"
+          export CPPFLAGS="-I$OPENSSL_PREFIX/include"
+          export DYLD_LIBRARY_PATH="$OPENSSL_PREFIX/lib:$DYLD_LIBRARY_PATH"
           perl Makefile.PL
           make
           make test

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,17 @@
 # Revision history for Perl extension Crypt::OpenSSL::X509
 
+## 2.1.3 2026-07-12
+
+- Fixed CVE-2026-58102: heap out-of-bounds read in `hv_exts()`. The function allocated a fixed 128-byte buffer for an extension's OID string but used `OBJ_obj2txt()`'s return value (the full required length, not the number of bytes actually written) as the key length passed to `hv_store()`. A certificate with an extension whose OID stringifies to more than 128 bytes caused a heap over-read. Fixed with a two-phase `OBJ_obj2txt()` call (probe the required length, allocate exactly, then format) and by using `strlen(key)` rather than the `OBJ_obj2txt()` return value for the `hv_store()` key length. This is a **security fix; update is strongly recommended**
+
+- Fixed CVE-2026-58101: NULL-pointer dereference in several `Crypt::OpenSSL::X509::Extension` helpers. `X509V3_EXT_d2i()` returns `NULL` when an extension's DER payload fails to parse, and the `AUTHORITY_KEYID` `keyid` field is legitimately `NULL` for Authority Key Identifiers that carry only issuer/serial. `basicC()`, `ia5string()`, `auth_att()`, and `keyid_data()` dereferenced these values unconditionally, allowing an attacker-supplied certificate to crash any process that parsed it. All four helpers now guard against `NULL`; `basicC()` croaks on unparseable DER (since it feeds a CA/pathLen security decision), the others fall back to safe empty values. This is a **security fix; update is strongly recommended**
+
+- Hardened `bit_string()` and `extendedKeyUsage()` with the same defence-in-depth `NULL` guards as the CVE-2026-58101 fix, for consistency across all extension helpers, even though the underlying OpenSSL calls were already `NULL`-tolerant
+
+- Fixed several memory leaks and undefined-behaviour issues found during review of the above fixes: `auth_att()` no longer leaks the `AUTHORITY_KEYID` on every call; `extendedKeyUsage()` no longer leaks the popped `ASN1_OBJECT`s or the `STACK_OF(ASN1_OBJECT)` container, and now guards `OBJ_nid2sn()`'s result (which can be `NULL` for unregistered NIDs) before passing it to `BIO_printf()`'s `%s` format; `bit_string()` no longer leaks the `ASN1_BIT_STRING` returned by `X509V3_EXT_d2i()`; `hv_exts()` now rejects empty OIDs and checks the return value of its second `OBJ_obj2txt()` call rather than assuming success
+
+- Documented `basicC()`, `ia5string()`, `bit_string()`, `auth_att()`, `keyid_data()`, and `extendedKeyUsage()` in the `Crypt::OpenSSL::X509::Extension` POD, explicitly noting that `basicC()` throws on malformed DER so callers should wrap it in `eval {}`
+
 ## 2.1.2 2026-06-25
 
 - Applied PR [#128](https://github.com/dsully/perl-crypt-openssl-x509/pull/128) from @maxbes (Maxime Besson) fixing `has_extension_oid` returning incorrect results when multiple certificates are instantiated in a single Perl process. The previous implementation stored the extension cache in a package variable, causing it to be shared across all certificate objects. The cache is now held per-instance, so each certificate object maintains its own independent extension list. This is a **bug fix release; update is recommended**. Contributed by @maxbes

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -78,7 +78,7 @@ my %WriteMakefileArgs = (
   "TEST_REQUIRES" => {
     "Test::Pod" => "1.00"
   },
-  "VERSION" => "2.1.2",
+  "VERSION" => "2.1.3",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/README.md
+++ b/README.md
@@ -248,6 +248,34 @@ On request:
 
     Return a human-readable version of the extension as formatted by X509V3\_EXT\_print. Note that this will return an empty string for OIDs with unknown ASN.1 encodings.
 
+- basicC ( TYPE )
+
+    Return the value of a basicConstraints field. `TYPE` must be `"ca"` (returns 1 if the certificate is a CA, 0 otherwise) or `"pathlen"` (returns the path length constraint, or 0 if absent).
+
+    **Throws** if the basicConstraints extension DER cannot be parsed. Callers that process certificates from untrusted sources should wrap this call in `eval {}`:
+
+        my $is_ca = eval { $ext->basicC('ca') } // 0;
+
+- ia5string ( )
+
+    Return the value of an IA5String extension (e.g. `nsComment`) as a string. Returns an empty string if the extension DER cannot be parsed.
+
+- bit\_string ( )
+
+    Return the bit-string value of a key usage or Netscape certificate type extension as a string of `0`/`1` characters. Returns an empty string if the extension DER cannot be parsed.
+
+- auth\_att ( )
+
+    Return 1 if the Authority Key Identifier extension contains a keyIdentifier field, 0 otherwise. Returns 0 if the extension DER cannot be parsed.
+
+- keyid\_data ( )
+
+    Return the key identifier octets from a subjectKeyIdentifier or authorityKeyIdentifier extension as a binary string. Returns an empty string if the extension DER cannot be parsed or if the optional keyIdentifier field is absent.
+
+- extendedKeyUsage ( )
+
+    Return the extended key usage OIDs as a space-separated string of short names (e.g. `"serverAuth clientAuth"`). OIDs with no registered short name are silently omitted. Returns an empty string if the extension DER cannot be parsed.
+
 ## X509::ObjectID METHODS
 
 - name ( )

--- a/X509.pm
+++ b/X509.pm
@@ -488,6 +488,34 @@ Return the value of the extension as an asn1parse(1) style hex dump.
 
 Return a human-readable version of the extension as formatted by X509V3_EXT_print. Note that this will return an empty string for OIDs with unknown ASN.1 encodings.
 
+=item basicC ( TYPE )
+
+Return the value of a basicConstraints field. C<TYPE> must be C<"ca"> (returns 1 if the certificate is a CA, 0 otherwise) or C<"pathlen"> (returns the path length constraint, or 0 if absent).
+
+B<Throws> if the basicConstraints extension DER cannot be parsed. Callers that process certificates from untrusted sources should wrap this call in C<eval {}>:
+
+    my $is_ca = eval { $ext->basicC('ca') } // 0;
+
+=item ia5string ( )
+
+Return the value of an IA5String extension (e.g. C<nsComment>) as a string. Returns an empty string if the extension DER cannot be parsed.
+
+=item bit_string ( )
+
+Return the bit-string value of a key usage or Netscape certificate type extension as a string of C<0>/C<1> characters. Returns an empty string if the extension DER cannot be parsed.
+
+=item auth_att ( )
+
+Return 1 if the Authority Key Identifier extension contains a keyIdentifier field, 0 otherwise. Returns 0 if the extension DER cannot be parsed.
+
+=item keyid_data ( )
+
+Return the key identifier octets from a subjectKeyIdentifier or authorityKeyIdentifier extension as a binary string. Returns an empty string if the extension DER cannot be parsed or if the optional keyIdentifier field is absent.
+
+=item extendedKeyUsage ( )
+
+Return the extended key usage OIDs as a space-separated string of short names (e.g. C<"serverAuth clientAuth">). OIDs with no registered short name are silently omitted. Returns an empty string if the extension DER cannot be parsed.
+
 =back
 
 =head2 X509::ObjectID METHODS

--- a/X509.pm
+++ b/X509.pm
@@ -8,7 +8,7 @@ use base qw(Exporter);
 
 use Convert::ASN1;
 
-use version; our $VERSION = version->declare('2.1.2');
+use version; our $VERSION = version->declare('2.1.3');
 
 our @EXPORT_OK = qw(
   FORMAT_UNDEF FORMAT_ASN1 FORMAT_TEXT FORMAT_PEM

--- a/X509.xs
+++ b/X509.xs
@@ -1152,6 +1152,12 @@ basicC(ext, value)
   /* retrieve the value of CA or pathlen in basicConstraints */
   bs = X509V3_EXT_d2i(ext);
 
+  /* X509V3_EXT_d2i() returns NULL when the extension's DER fails to parse.
+     basicC() feeds a security decision (callers test CA / pathLenConstraint),
+     so a malformed extension must be rejected rather than silently treated
+     as ca=0 / pathlen=0. Croak instead of dereferencing NULL. */
+  if (bs == NULL) croak("Error parsing basicConstraints extension\n");
+
   if (strcmp(value, "ca") == 0) {
     ret = bs->ca ? 1 : 0;
 
@@ -1179,13 +1185,17 @@ ia5string(ext)
   /* retrieving the value of an ia5string object */
   bio = sv_bio_create();
   str = X509V3_EXT_d2i(ext);
+  /* X509V3_EXT_d2i() returns NULL on a malformed extension; guard the
+     dereference and return an empty string rather than crashing. */
+  if (str != NULL) {
 #if OPENSSL_VERSION_NUMBER >= 0x40000000L
-  BIO_write(bio, ASN1_STRING_get0_data((ASN1_STRING *)str),
-                 ASN1_STRING_length((ASN1_STRING *)str));
+    BIO_write(bio, ASN1_STRING_get0_data((ASN1_STRING *)str),
+                   ASN1_STRING_length((ASN1_STRING *)str));
 #else
-  BIO_write(bio, str->data, str->length);
+    BIO_write(bio, str->data, str->length);
 #endif
-  ASN1_IA5STRING_free(str);
+    ASN1_IA5STRING_free(str);
+  }
 
   RETVAL = sv_bio_final(bio);
 
@@ -1267,7 +1277,11 @@ auth_att(ext)
   CODE:
 
   akid   = X509V3_EXT_d2i(ext);
-  RETVAL = akid->keyid ? 1 : 0;
+  /* akid is NULL on a malformed extension, and a well-formed AUTHORITY_KEYID
+     may legitimately have a NULL optional keyid field -- both must not be
+     dereferenced. Also free akid, which the original code leaked. */
+  RETVAL = (akid != NULL && akid->keyid != NULL) ? 1 : 0;
+  if (akid != NULL) AUTHORITY_KEYID_free(akid);
 
   OUTPUT:
   RETVAL
@@ -1293,28 +1307,38 @@ keyid_data(ext)
   if (nid == NID_authority_key_identifier) {
 
     akid = X509V3_EXT_d2i(ext);
+    /* akid is NULL on a malformed AKI; akid->keyid is an optional field that
+       is legitimately NULL (e.g. an AKI carrying only issuer/serial). Guard
+       both before dereferencing -- otherwise either is a NULL-deref crash. */
+    if (akid != NULL) {
+      if (akid->keyid != NULL) {
 #if OPENSSL_VERSION_NUMBER >= 0x40000000L
-    p   = ASN1_STRING_get0_data((ASN1_STRING *)akid->keyid);
-    len = ASN1_STRING_length((ASN1_STRING *)akid->keyid);
+        p   = ASN1_STRING_get0_data((ASN1_STRING *)akid->keyid);
+        len = ASN1_STRING_length((ASN1_STRING *)akid->keyid);
 #else
-    p   = akid->keyid->data;
-    len = akid->keyid->length;
+        p   = akid->keyid->data;
+        len = akid->keyid->length;
 #endif
-    BIO_write(bio, p, len);
-    AUTHORITY_KEYID_free(akid);
+        BIO_write(bio, p, len);
+      }
+      AUTHORITY_KEYID_free(akid);
+    }
 
   } else if (nid == NID_subject_key_identifier) {
 
     skid = X509V3_EXT_d2i(ext);
+    /* skid is NULL on a malformed subjectKeyIdentifier; guard the deref. */
+    if (skid != NULL) {
 #if OPENSSL_VERSION_NUMBER >= 0x40000000L
-    p   = ASN1_STRING_get0_data((ASN1_STRING *)skid);
-    len = ASN1_STRING_length((ASN1_STRING *)skid);
+      p   = ASN1_STRING_get0_data((ASN1_STRING *)skid);
+      len = ASN1_STRING_length((ASN1_STRING *)skid);
 #else
-    p   = skid->data;
-    len = skid->length;
+      p   = skid->data;
+      len = skid->length;
 #endif
-    BIO_write(bio, p, len);
-    ASN1_OCTET_STRING_free(skid);
+      BIO_write(bio, p, len);
+      ASN1_OCTET_STRING_free(skid);
+    }
   }
 
   RETVAL = sv_bio_final(bio);

--- a/X509.xs
+++ b/X509.xs
@@ -1220,18 +1220,22 @@ bit_string(ext)
   nid = OBJ_obj2nid(object);
   bit_str = X509V3_EXT_d2i(ext);
 
-  if (nid == NID_key_usage) {
+  /* ASN1_BIT_STRING_get_bit() is NULL-tolerant (returns 0 for NULL), so
+     this guard is defence-in-depth rather than a crash fix. */
+  if (bit_str != NULL) {
+    if (nid == NID_key_usage) {
 
-    for (i = 0; i < 9; i++) {
-      string[i] = (int)ASN1_BIT_STRING_get_bit(bit_str, i);
-      BIO_printf(bio, "%d", string[i]);
-    }
+      for (i = 0; i < 9; i++) {
+        string[i] = (int)ASN1_BIT_STRING_get_bit(bit_str, i);
+        BIO_printf(bio, "%d", string[i]);
+      }
 
-  } else if (nid == NID_netscape_cert_type) {
+    } else if (nid == NID_netscape_cert_type) {
 
-    for (i = 0; i < 8; i++) {
-      string[i] = (int)ASN1_BIT_STRING_get_bit(bit_str, i);
-      BIO_printf(bio, "%d",  string[i]);
+      for (i = 0; i < 8; i++) {
+        string[i] = (int)ASN1_BIT_STRING_get_bit(bit_str, i);
+        BIO_printf(bio, "%d",  string[i]);
+      }
     }
   }
 
@@ -1255,11 +1259,20 @@ extendedKeyUsage(ext)
   bio   = sv_bio_create();
   extku = (STACK_OF(ASN1_OBJECT)*) X509V3_EXT_d2i(ext);
 
-  while(sk_ASN1_OBJECT_num(extku) > 0) {
-    nid = OBJ_obj2nid(sk_ASN1_OBJECT_pop(extku));
-    value = OBJ_nid2sn(nid);
-    BIO_printf(bio, "%s", value);
-    BIO_printf(bio, " ");
+  /* OPENSSL_sk_num(NULL) returns -1 so the loop body never runs on NULL
+     extku -- this guard is defence-in-depth. The real fix here is freeing
+     both the popped ASN1_OBJECTs and the stack container, which the
+     original code leaked on every call. */
+  if (extku != NULL) {
+    ASN1_OBJECT *obj;
+    while((obj = sk_ASN1_OBJECT_pop(extku)) != NULL) {
+      nid = OBJ_obj2nid(obj);
+      ASN1_OBJECT_free(obj);
+      value = OBJ_nid2sn(nid);
+      BIO_printf(bio, "%s", value);
+      BIO_printf(bio, " ");
+    }
+    sk_ASN1_OBJECT_free(extku);
   }
 
   RETVAL = sv_bio_final(bio);

--- a/X509.xs
+++ b/X509.xs
@@ -259,7 +259,6 @@ static SV* sv_make_ref(const char* class, void* object) {
 static HV* hv_exts(X509* x509, int no_name) {
   X509_EXTENSION *ext;
   int i, c, r;
-  size_t len = 128;
   char* key = NULL;
   const char* ckey = NULL;
   SV* rv;
@@ -284,9 +283,22 @@ static HV* hv_exts(X509* x509, int no_name) {
 
     if (no_name == 0 || no_name == 1) {
 
-       key = malloc(sizeof(char) * (len + 1)); /*FIXME will it leak?*/
-       r = OBJ_obj2txt(key, len, X509_EXTENSION_get_object(ext), no_name);
+       /* OBJ_obj2txt() returns the FULL textual length the OID needs, not
+          the number of bytes written into the buffer. The original code
+          passed a fixed 128-byte buffer and handed that return value to
+          hv_store() as the key length, so an OID longer than 128 bytes made
+          hv_store() read past the allocation (heap OOB read). Size the
+          buffer to the required length first, then format, and store the
+          number of bytes actually written (strlen) -- never the return
+          value -- so no over-read is possible on any code path or any
+          OBJ_obj2txt() version. */
+       r = OBJ_obj2txt(NULL, 0, X509_EXTENSION_get_object(ext), no_name);
+       if (r < 0) { SvREFCNT_dec(rv); croak("OBJ_obj2txt length query failed for extension %d\n", i); }
+       key = malloc(sizeof(char) * ((size_t)r + 1));
+       if (key == NULL) { SvREFCNT_dec(rv); croak("malloc failed for extension key\n"); }
+       OBJ_obj2txt(key, r + 1, X509_EXTENSION_get_object(ext), no_name);
        ckey = key;
+       r = (int)strlen(key);
 
     } else if (no_name == 2) {
 
@@ -294,7 +306,15 @@ static HV* hv_exts(X509* x509, int no_name) {
        r = strlen(ckey);
     }
 
-    if (! hv_store(RETVAL, ckey, r, rv, 0) ) croak("Error storing extension in hash\n");
+    /* hv_store() copies the key bytes, so the per-iteration key buffer can be
+       freed immediately. Free it BEFORE the failure croak so it is not leaked
+       on longjmp; on hv_store() failure the hash did not adopt rv, so drop
+       our reference too. */
+    {
+        SV** stored = hv_store(RETVAL, ckey, r, rv, 0);
+        if (key != NULL) { free(key); key = NULL; }
+        if (stored == NULL) { SvREFCNT_dec(rv); croak("Error storing extension in hash\n"); }
+    }
   }
 
   return RETVAL;

--- a/X509.xs
+++ b/X509.xs
@@ -293,16 +293,20 @@ static HV* hv_exts(X509* x509, int no_name) {
           value -- so no over-read is possible on any code path or any
           OBJ_obj2txt() version. */
        r = OBJ_obj2txt(NULL, 0, X509_EXTENSION_get_object(ext), no_name);
-       if (r < 0) { SvREFCNT_dec(rv); croak("OBJ_obj2txt length query failed for extension %d\n", i); }
+       if (r <= 0) { SvREFCNT_dec(rv); croak("OBJ_obj2txt length query failed for extension %d\n", i); }
        key = malloc(sizeof(char) * ((size_t)r + 1));
        if (key == NULL) { SvREFCNT_dec(rv); croak("malloc failed for extension key\n"); }
-       OBJ_obj2txt(key, r + 1, X509_EXTENSION_get_object(ext), no_name);
+       if (OBJ_obj2txt(key, r + 1, X509_EXTENSION_get_object(ext), no_name) < 0) {
+         free(key); key = NULL; SvREFCNT_dec(rv);
+         croak("OBJ_obj2txt format failed for extension %d\n", i);
+       }
        ckey = key;
        r = (int)strlen(key);
 
     } else if (no_name == 2) {
 
        ckey = OBJ_nid2sn(OBJ_obj2nid(X509_EXTENSION_get_object(ext)));
+       if (ckey == NULL) { SvREFCNT_dec(rv); croak("OBJ_nid2sn failed for extension %d\n", i); }
        r = strlen(ckey);
     }
 
@@ -1237,6 +1241,7 @@ bit_string(ext)
         BIO_printf(bio, "%d",  string[i]);
       }
     }
+    ASN1_BIT_STRING_free(bit_str);
   }
 
   RETVAL = sv_bio_final(bio);
@@ -1269,8 +1274,9 @@ extendedKeyUsage(ext)
       nid = OBJ_obj2nid(obj);
       ASN1_OBJECT_free(obj);
       value = OBJ_nid2sn(nid);
-      BIO_printf(bio, "%s", value);
-      BIO_printf(bio, " ");
+      if (value != NULL) {
+        BIO_printf(bio, "%s ", value);
+      }
     }
     sk_ASN1_OBJECT_free(extku);
   }

--- a/X509.xs
+++ b/X509.xs
@@ -292,7 +292,14 @@ static HV* hv_exts(X509* x509, int no_name) {
           number of bytes actually written (strlen) -- never the return
           value -- so no over-read is possible on any code path or any
           OBJ_obj2txt() version. */
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
        r = OBJ_obj2txt(NULL, 0, X509_EXTENSION_get_object(ext), no_name);
+#else
+       {
+         char tmp[1];
+         r = OBJ_obj2txt(tmp, sizeof(tmp), X509_EXTENSION_get_object(ext), no_name);
+       }
+#endif
        if (r <= 0) { SvREFCNT_dec(rv); croak("OBJ_obj2txt length query failed for extension %d\n", i); }
        key = malloc(sizeof(char) * ((size_t)r + 1));
        if (key == NULL) { SvREFCNT_dec(rv); croak("malloc failed for extension key\n"); }

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -58,3 +58,51 @@ the container after the loop. The elements are popped (and their memory freed by
 
 Fix: add `sk_ASN1_OBJECT_free(extku);` after the while loop, inside the `if (extku != NULL)`
 block.
+
+---
+
+## Follow-up from macOS CI OpenSSL version discussion
+
+### 5. `macos-latest.yml` only tests a single OpenSSL version per run
+
+The workflow currently installs one Homebrew OpenSSL formula (`openssl@3`) and points
+`OPENSSL_PREFIX` at it. This matches the pattern used for multi-version testing locally
+(`scripts/test.sh`, `OPENSSL4_TESTING.md`), but CI still only exercises one version per
+push, unlike the local script which loops over 1.1/3.0/3.5/4.x.
+
+Consider converting the `Run Tests` step to a build matrix so PRs are checked against
+multiple OpenSSL versions on macOS, e.g.:
+
+```yaml
+strategy:
+  fail-fast: false
+  matrix:
+    openssl: ["openssl@1.1", "openssl@3"]
+
+steps:
+  - uses: actions/checkout@v4.2.0
+  - name: install dependencies
+    run: |
+      brew install ${{ matrix.openssl }}
+  - name: uses install-with-cpanm
+    uses: perl-actions/install-with-cpanm@v1.7
+    with:
+      cpanfile: "cpanfile"
+      args: "--with-configure"
+      sudo: false
+  - name: perl -V
+    run: perl -V
+  - name: Run Tests
+    run: |
+      export OPENSSL_PREFIX="$(brew --prefix ${{ matrix.openssl }})"
+      export PKG_CONFIG_PATH="$OPENSSL_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
+      export LDFLAGS="-L$OPENSSL_PREFIX/lib"
+      export CPPFLAGS="-I$OPENSSL_PREFIX/include"
+      export DYLD_LIBRARY_PATH="$OPENSSL_PREFIX/lib:$DYLD_LIBRARY_PATH"
+      perl Makefile.PL
+      make
+      make test
+```
+
+Using `brew --prefix` instead of a hardcoded `/opt/homebrew/opt/...` path also avoids
+breakage on Intel runners (`/usr/local`) vs Apple Silicon runners (`/opt/homebrew`).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -44,3 +44,17 @@ sub Crypt::OpenSSL::X509::has_extension_oid {
 Neither test for `has_extension_oid` uses a cert with zero extensions, so the croak in
 item 1 goes undetected by CI. A test using a minimal cert (or mocking
 `extensions_by_oid` to croak) should be added alongside the fix for item 1.
+
+---
+
+## Follow-up from CVE-2026-58101 fix
+
+### 4. `extendedKeyUsage` leaks the STACK_OF(ASN1_OBJECT) container
+
+`extendedKeyUsage()` in `X509.xs` (~line 1236) drains the stack with `sk_ASN1_OBJECT_pop`
+inside the NULL guard added for CVE-2026-58101, but never calls `sk_ASN1_OBJECT_free()` on
+the container after the loop. The elements are popped (and their memory freed by
+`sk_ASN1_OBJECT_pop` → `ASN1_OBJECT_free`), but the `STACK_OF` header itself leaks.
+
+Fix: add `sk_ASN1_OBJECT_free(extku);` after the while loop, inside the `if (extku != NULL)`
+block.

--- a/docs/code-review-2026-07-11.md
+++ b/docs/code-review-2026-07-11.md
@@ -1,0 +1,99 @@
+# Code Review Findings — Branch `fix/CVE-2026-58101-CVE-2026-58102`
+
+**Date:** 2026-07-11
+**Effort:** High (8 angles × parallel verify)
+**Scope:** `X509.xs` diff against `master` (3 commits: CVE-2026-58102 hv_exts fix, CVE-2026-58101 extension-helper NULL guards, defence-in-depth + extendedKeyUsage leak fix)
+
+---
+
+## CONFIRMED findings
+
+### 1. `bit_string()` leaks `ASN1_BIT_STRING` on every call — X509.xs ~line 1221
+
+`X509V3_EXT_d2i()` returns a caller-owned allocation. The sibling functions `basicC()` and `ia5string()` both free their allocations (`BASIC_CONSTRAINTS_free(bs)`, `ASN1_IA5STRING_free(str)`). The new `if (bit_str != NULL)` block in `bit_string()` uses `bit_str` but has no corresponding `ASN1_BIT_STRING_free(bit_str)`.
+
+**Fix:** add `ASN1_BIT_STRING_free(bit_str);` after the closing brace of the `if (bit_str != NULL)` block, matching the pattern in `ia5string()`.
+
+---
+
+### 2. `extendedKeyUsage()` — `BIO_printf("%s", NULL)` UB on custom EKU OIDs — X509.xs ~line 1272
+
+After `ASN1_OBJECT_free(obj)` the code does:
+```c
+value = OBJ_nid2sn(nid);
+BIO_printf(bio, "%s", value);
+```
+`OBJ_obj2nid()` returns `NID_undef` for any OID not in OpenSSL's built-in table; `OBJ_nid2sn(NID_undef)` returns `NULL`. A certificate carrying a private or custom extended key usage OID causes `BIO_printf(bio, "%s", NULL)` — undefined behaviour, crash in practice.
+
+**Fix:** guard the printf:
+```c
+value = OBJ_nid2sn(nid);
+if (value != NULL) {
+    BIO_printf(bio, "%s ", value);
+}
+```
+Or fall back to a dotted-decimal representation for unrecognised NIDs to preserve them in the output.
+
+---
+
+### 3. `basicC()` croak is undocumented — no caller wraps it in `eval{}` — X509.xs ~line 1159
+
+The new `if (bs == NULL) croak("Error parsing basicConstraints extension\n")` throws a fatal Perl exception for a malformed `basicConstraints` extension. `X509.pm` POD documents no exception from `basicC()`; `t/x509.t` calls it bare without `eval{}`. Any caller processing attacker-supplied certificates will receive an uncaught fatal error rather than a distinguishable false return. This is a silent breaking API change.
+
+**Fix:** document the exception in `X509.pm` POD for `basicC()`. Consider wrapping call sites (or advising callers to do so), consistent with the `eval{}` pattern already used in `subjectaltname()` (X509.pm line 93–96).
+
+---
+
+## PLAUSIBLE findings
+
+### 4. Second `OBJ_obj2txt()` call return value discarded — `strlen()` on uninitialised buffer if it fails — X509.xs ~line 299
+
+The probe call at line 295 is checked for `< 0`. The formatting call at line 299:
+```c
+OBJ_obj2txt(key, r + 1, X509_EXTENSION_get_object(ext), no_name);
+```
+is not checked. If it returns `-1` (e.g. internal BIO error or pre-existing OpenSSL error state), `key[]` was `malloc`'d (not `calloc`'d) and contains uninitialised bytes. `strlen(key)` then reads past the `r+1`-byte allocation and the resulting garbage length is passed to `hv_store()`.
+
+**Fix:** capture the return value and croak on failure:
+```c
+if (OBJ_obj2txt(key, r + 1, X509_EXTENSION_get_object(ext), no_name) < 0) {
+    free(key); SvREFCNT_dec(rv);
+    croak("OBJ_obj2txt format failed for extension %d\n", i);
+}
+```
+
+---
+
+### 5. `strlen(ckey)` in `no_name==2` branch has no NULL guard — X509.xs ~line 306
+
+```c
+ckey = OBJ_nid2sn(OBJ_obj2nid(X509_EXTENSION_get_object(ext)));
+r = strlen(ckey);
+```
+`OBJ_nid2sn()` returns `NULL` when a NID was registered via `OBJ_create()` with a `NULL` short-name. This line is unchanged in a touched function; `strlen(NULL)` is undefined behaviour. The `r < 0` guard added to the `no_name==0/1` branch in this diff has no equivalent here.
+
+**Fix:**
+```c
+if (ckey == NULL) croak("OBJ_nid2sn failed for extension %d\n", i);
+```
+
+---
+
+### 6. No guard against `r==0` from `OBJ_obj2txt` probe — extension silently stored under empty-string key — X509.xs ~line 296
+
+The guard at line 296 rejects only `r < 0`. If the probe returns `0` (corrupt or empty `ASN1_OBJECT` inside an extension), `malloc(1)` is called, the second `OBJ_obj2txt` call writes only `'\0'`, `strlen` returns `0`, and `hv_store` inserts the extension under key `""`. A second such extension silently overwrites the first. Under `no_name==0` and `no_name==1`, a valid OID always produces a positive length (fallback to dotted-decimal), so the trigger requires a malformed extension object — but the gap is unguarded.
+
+**Fix:** treat `r == 0` as an error alongside `r < 0`:
+```c
+if (r <= 0) { SvREFCNT_dec(rv); croak("OBJ_obj2txt length query failed for extension %d\n", i); }
+```
+
+---
+
+## Refuted / out of scope
+
+| Candidate | Verdict | Reason |
+|---|---|---|
+| `extendedKeyUsage` reverses EKU order | REFUTED | Pop-based loop pre-existed the patch; order was already LIFO before this diff |
+| `extKeyUsage()` — `split(/ /, "")` false positive | REFUTED | Perl's `split(/ /, "")` returns an empty list, not `("")` |
+| `ObjectID::name`/`::oid` still use 128-byte fixed buffer | Out of scope | Pre-existing; not introduced by this branch — log as separate TODO |

--- a/docs/code-review-2026-07-11.md
+++ b/docs/code-review-2026-07-11.md
@@ -4,6 +4,8 @@
 **Effort:** High (8 angles × parallel verify)
 **Scope:** `X509.xs` diff against `master` (3 commits: CVE-2026-58102 hv_exts fix, CVE-2026-58101 extension-helper NULL guards, defence-in-depth + extendedKeyUsage leak fix)
 
+**Status:** The findings below were identified during review of earlier snapshots and have since been addressed in later commits on this branch; keep this document as historical review notes rather than a statement of current defects.
+
 ---
 
 ## CONFIRMED findings


### PR DESCRIPTION
- **Fix CVE-2026-58102: heap OOB-read in hv_exts() on long-OID extensions**
- **Fix CVE-2026-58101: NULL-deref in X509V3_EXT_d2i extension helpers**
- **Defence-in-depth NULL guards + fix extendedKeyUsage object/stack leak**
- **Fix code review findings: memory leak, UB, unchecked returns, missing guards**
- **Updated docs with findings, review and status**
- **Preparing release 2.1.3**
